### PR TITLE
fixing error if pointing $ref to absolute path

### DIFF
--- a/docson.js
+++ b/docson.js
@@ -481,7 +481,8 @@ define(["lib/jquery", "lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib
                             //Local to this server, fetch relative
                             var segments = item.split("#");
                             refs[item] = null;
-                            var p = $.get(baseUrl + segments[0]).then(function(content) {
+                            var isRelativeLink = /^[^\/]/.test(segments[0]);
+                            var p = $.get((isRelativeLink ? baseUrl:"") + segments[0]).then(function(content) {
                                 if(typeof content != "object") {
                                     try {
                                         content = JSON.parse(content);


### PR DESCRIPTION
If you use an absolute path as a $ref it does not get picked up by the app and you end up getting a 404.

Example $ref:"/data/schema.json" works now